### PR TITLE
added "retry" option to SetOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -735,7 +735,6 @@ import { flatten } from "https://deno.land/x/kvdex/mod.ts"
 
 // We assume the document exists in the KV store
 const doc = await db.users.find(123n)
-
 const flattened = flatten(doc)
 
 // Document:
@@ -749,7 +748,7 @@ const flattened = flatten(doc)
 // {
 //   id,
 //   versionstamp,
-//   ...userDocument.value
+//   ...value
 // }
 ```
 

--- a/src/atomic_builder.ts
+++ b/src/atomic_builder.ts
@@ -4,6 +4,7 @@ import { LargeCollection } from "./large_collection.ts"
 import type {
   AtomicCheck,
   AtomicMutation,
+  AtomicSetOptions,
   CollectionOptions,
   CollectionSelector,
   IndexableCollectionOptions,
@@ -13,7 +14,6 @@ import type {
   Operations,
   Schema,
   SchemaDefinition,
-  SetOptions,
 } from "./types.ts"
 import {
   allFulfilled,
@@ -106,7 +106,7 @@ export class AtomicBuilder<
    * @param options - Set options, optional.
    * @returns Current AtomicBuilder instance.
    */
-  add(data: T2, options?: SetOptions) {
+  add(data: T2, options?: AtomicSetOptions) {
     // Generate id and perform set operation
     const id = this.collection._idGenerator(data)
     return this.set(id, data, options)
@@ -130,7 +130,7 @@ export class AtomicBuilder<
    * @param options - Set options, optional.
    * @returns Current AtomicBuilder instance.
    */
-  set(id: KvId, data: T2, options?: SetOptions) {
+  set(id: KvId, data: T2, options?: AtomicSetOptions) {
     // Create id key from collection id key and id
     const collectionKey = this.collection._keys.idKey
     const idKey = extendKey(collectionKey, id)

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,6 +75,10 @@ export type AtomicMutation<T extends KvValue> =
     }
   )
 
+export type AtomicSetOptions = NonNullable<
+  Parameters<ReturnType<Deno.Kv["atomic"]>["set"]>["2"]
+>
+
 // Collection Types
 export type IdGenerator<T extends KvValue> = (data: T) => KvId
 
@@ -90,7 +94,9 @@ export type CollectionKeys = {
   idKey: KvKey
 }
 
-export type SetOptions = NonNullable<Parameters<Deno.Kv["set"]>["2"]>
+export type SetOptions = NonNullable<Parameters<Deno.Kv["set"]>["2"]> & {
+  retry?: number
+}
 
 export type ListOptions<T extends KvValue> = Deno.KvListOptions & {
   /**

--- a/src/utils.internal.ts
+++ b/src/utils.internal.ts
@@ -4,6 +4,7 @@ import {
 } from "./constants.ts"
 import type { IndexableCollection } from "./indexable_collection.ts"
 import type {
+  AtomicSetOptions,
   FindManyOptions,
   IndexableCollectionOptions,
   IndexDataEntry,
@@ -13,7 +14,6 @@ import type {
   Model,
   ParsedQueueMessage,
   QueueMessage,
-  SetOptions,
   UpdateData,
 } from "./types.ts"
 
@@ -122,7 +122,7 @@ export function setIndices<
   data: T1,
   atomic: Deno.AtomicOperation,
   collection: IndexableCollection<T1, T2>,
-  options: SetOptions | undefined,
+  options: AtomicSetOptions | undefined,
 ) {
   // Set mutable copy of atomic operation
   let op = atomic
@@ -183,7 +183,7 @@ export function setIndices<
  */
 export function checkIndices<
   T1 extends Model,
-  T2 extends UpdateData<T1>,
+  T2 extends T1 | UpdateData<T1>,
   T3 extends IndexableCollectionOptions<T1>,
 >(
   data: T2,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,9 +6,23 @@ import type { Document, FlattenedDocument, Model } from "./types.ts"
  *
  * **Example:**
  * ```ts
- * const userDoc = await db.users.find("oliver")
+ * // We assume the document exists in the KV store
+ * const doc = await db.users.find(123n)
+ * const flattened = flatten(doc)
  *
- * const user = flatten(userDoc)
+ * // Document:
+ * // {
+ * //   id,
+ * //   versionstamp,
+ * //   value
+ * // }
+ *
+ * // Flattened:
+ * // {
+ * //   id,
+ * //   versionstamp,
+ * //   ...value
+ * // }
  * ```
  *
  * @param document - The document to flatten.

--- a/test/tests/indexable_collection.test.ts
+++ b/test/tests/indexable_collection.test.ts
@@ -210,24 +210,39 @@ Deno.test("indexable_collection", async (t) => {
         await reset()
 
         const id = "id"
+
+        const crPrep = await db.indexablePeople.set(id, testPerson)
+        assert(crPrep.ok)
+
+        const cr = await db.indexablePeople.write(id, testPerson2)
+        assert(cr.ok)
+        assert(cr.id === id)
+
+        const doc = await db.indexablePeople.find(id)
+        assert(doc !== null)
+        assert(doc.value.name === testPerson2.name)
+
+        const count = await db.indexablePeople.count({
+          filter: (doc) => doc.value.name === testPerson2.name,
+        })
+
+        assert(count === 1)
+      },
+    )
+
+    await t.step(
+      "Should not write over existing document in the collection with index collisions",
+      async () => {
+        await reset()
+
+        const id = "id"
         const value = testPerson
 
         const crPrep = await db.indexablePeople.set(id, value)
         assert(crPrep.ok)
 
         const cr = await db.indexablePeople.write(id, value)
-        assert(cr.ok)
-        assert(cr.id === id)
-
-        const doc = await db.indexablePeople.find(id)
-        assert(doc !== null)
-        assert(doc.value.name === value.name)
-
-        const count = await db.indexablePeople.count({
-          filter: (doc) => doc.value.name === value.name,
-        })
-
-        assert(count === 1)
+        assert(!cr.ok)
       },
     )
   })


### PR DESCRIPTION
Added "retry" option to SetOptions to allow retying a given number of times on failed operations. 
This provides the following methods with retry functionality:

- add()
- set()
- write()
- update()
- updateMany()
- addMany()
- updateByPrimaryIndex()
- updateBySecondaryIndex()

Idea proposed by @jocades