### PR TITLE
remove operation ref to atomic object

### DIFF
--- a/src/indexable_collection.ts
+++ b/src/indexable_collection.ts
@@ -215,8 +215,8 @@ export class IndexableCollection<
       }
 
       // Perform delete using atomic operation
-      let atomic = this.kv.atomic().delete(idKey)
-      atomic = deleteIndices(id, value, atomic, this)
+      const atomic = this.kv.atomic().delete(idKey)
+      deleteIndices(id, value, atomic, this)
       await atomic.commit()
     }))
   }
@@ -463,12 +463,12 @@ export class IndexableCollection<
     }
 
     // Create atomic operation with set mutation and versionstamp check
-    let atomic = this.kv
+    const atomic = this.kv
       .atomic()
       .set(idKey, data, options)
 
     // Set document indices using atomic operation
-    atomic = setIndices(id, data, atomic, this, options)
+    setIndices(id, data, atomic, this, options)
 
     // Execute the atomic operation
     const cr = await atomic.commit()

--- a/src/utils.internal.ts
+++ b/src/utils.internal.ts
@@ -124,9 +124,6 @@ export function setIndices<
   collection: IndexableCollection<T1, T2>,
   options: AtomicSetOptions | undefined,
 ) {
-  // Set mutable copy of atomic operation
-  let op = atomic
-
   // Set primary indices using primary index list
   collection.primaryIndexList.forEach((index) => {
     // Get the index value from data, if undefined continue to next index
@@ -144,7 +141,7 @@ export function setIndices<
     const indexEntry: IndexDataEntry<T1> = { ...data, __id__: id }
 
     // Add index insertion to atomic operation, check for exisitng indices
-    op = op.set(indexKey, indexEntry, options).check({
+    atomic.set(indexKey, indexEntry, options).check({
       key: indexKey,
       versionstamp: null,
     })
@@ -165,11 +162,11 @@ export function setIndices<
     )
 
     // Add index insertion to atomic operation, check for exisitng indices
-    op = op.set(indexKey, data, options)
+    atomic.set(indexKey, data, options)
   })
 
   // Return the mutated atomic operation
-  return op
+  return atomic
 }
 
 /**
@@ -190,9 +187,6 @@ export function checkIndices<
   atomic: Deno.AtomicOperation,
   collection: IndexableCollection<T1, T3>,
 ) {
-  // Set mutable copy of atomic operation
-  let op = atomic
-
   // Check primary indices using primary index list
   collection.primaryIndexList.forEach((index) => {
     // Get the index value from data, if undefined continue to next index
@@ -209,14 +203,14 @@ export function checkIndices<
     )
 
     // Check for existing index entry
-    op = op.check({
+    atomic.check({
       key: indexKey,
       versionstamp: null,
     })
   })
 
   // Return the mutated atomic operation
-  return op
+  return atomic
 }
 
 /**
@@ -237,9 +231,6 @@ export function deleteIndices<
   atomic: Deno.AtomicOperation,
   collection: IndexableCollection<T1, T2>,
 ) {
-  // Set mutable copy of atomic operation
-  let op = atomic
-
   // Delete primary indices using primary index list
   collection.primaryIndexList.forEach((index) => {
     // Get the index value from data, if undefined continue to next index
@@ -254,7 +245,7 @@ export function deleteIndices<
     )
 
     // Add index deletion to atomic operation
-    op = op.delete(indexKey)
+    atomic.delete(indexKey)
   })
 
   // Delete seocndary indices using secondary index list
@@ -272,10 +263,10 @@ export function deleteIndices<
     )
 
     // Add index deletion to atomic operation
-    op = op.delete(indexKey)
+    atomic.delete(indexKey)
   })
 
-  return op
+  return atomic
 }
 
 /**


### PR DESCRIPTION
### Remove unnecessary assignment of op to atomic

- I've removed the unnecessary assignment of op to atomic, as JavaScript objects are assigned by reference. This means that atomic itself is already a reference to the same object, so there's no need to reassign it.
- By directly calling atomic.check, we enhance code readability and slightly improve performance.

This behavior is somewhat similar to how pointers work in languages like C. In C, when you assign a variable to a pointer, you're essentially assigning the memory address where the data is stored

```c
int value = 42;
int* p = &value;
```

PD: Tests for the indexable_collection are failing in the 'main' branch, but this had nothing to do with it.
