### PR TITLE
Async kv map

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@olli/kvdex",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "exports": {
     ".": "./mod.ts",
     "./zod": "./src/ext/zod/mod.ts",

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -439,7 +439,7 @@ export class Collection<
 
     // Create hsitory entries iterator
     const listOptions = createListOptions(options);
-    const iter = this.kv.list(selector, listOptions);
+    const iter = await this.kv.list(selector, listOptions);
 
     // Collect history entries
     let count = 0;
@@ -1258,7 +1258,7 @@ export class Collection<
     // Perform quick delete if all documents are to be deleted
     if (selectsAll(options)) {
       // Create list iterator and empty keys list, init atomic operation
-      const iter = this.kv.list({ prefix: this._keys.base }, options);
+      const iter = await this.kv.list({ prefix: this._keys.base }, options);
 
       const keys: DenoKvStrictKey[] = [];
       const atomic = new AtomicWrapper(this.kv);
@@ -1270,7 +1270,8 @@ export class Collection<
 
       // Set history entries if keeps history
       if (this._keepsHistory) {
-        for await (const { key } of this.kv.list({ prefix: this._keys.id })) {
+        const historyIter = await this.kv.list({ prefix: this._keys.id });
+        for await (const { key } of historyIter) {
           const id = getDocumentId(key as DenoKvStrictKey);
 
           if (!id) {
@@ -1836,7 +1837,7 @@ export class Collection<
 
     // Perform efficient count if counting all document entries
     if (selectsAll(options)) {
-      const iter = this.kv.list({ prefix: this._keys.id }, options);
+      const iter = await this.kv.list({ prefix: this._keys.id }, options);
       for await (const _ of iter) {
         result++;
       }
@@ -2073,8 +2074,8 @@ export class Collection<
     const atomic = new AtomicWrapper(this.kv);
     const historyKeyPrefix = extendKey(this._keys.history, id);
     const historySegmentKeyPrefix = extendKey(this._keys.historySegment, id);
-    const historyIter = this.kv.list({ prefix: historyKeyPrefix });
-    const historySegmentIter = this.kv.list({
+    const historyIter = await this.kv.list({ prefix: historyKeyPrefix });
+    const historySegmentIter = await this.kv.list({
       prefix: historySegmentKeyPrefix,
     });
 
@@ -2464,7 +2465,7 @@ export class Collection<
     if (this._encoder) {
       const atomic = new AtomicWrapper(this.kv);
       const keyPrefix = extendKey(this._keys.segment, id);
-      const iter = this.kv.list({ prefix: keyPrefix });
+      const iter = await this.kv.list({ prefix: keyPrefix });
 
       for await (const { key } of iter) {
         atomic.delete(key as DenoKvStrictKey);
@@ -2585,7 +2586,7 @@ export class Collection<
     // Create list iterator with given options
     const selector = createListSelector(prefixKey, options);
     const listOptions = createListOptions(options);
-    const iter = this.kv.list(selector, listOptions);
+    const iter = await this.kv.list(selector, listOptions);
 
     // Initiate lists
     const docs: Document<TOutput, ParseId<TOptions>>[] = [];

--- a/src/ext/kv/async_lock.ts
+++ b/src/ext/kv/async_lock.ts
@@ -1,0 +1,26 @@
+export class AsyncLock {
+  private queue: PromiseWithResolvers<void>[];
+
+  constructor() {
+    this.queue = [];
+  }
+
+  async lock() {
+    const prev = this.queue.at(-1);
+    const next = Promise.withResolvers<void>();
+    this.queue.push(next);
+    await prev?.promise;
+  }
+
+  release() {
+    const lock = this.queue.shift();
+    lock?.resolve();
+  }
+
+  async cancel() {
+    for (const lock of this.queue) {
+      lock.resolve();
+      await lock.promise;
+    }
+  }
+}

--- a/src/ext/kv/map_kv.ts
+++ b/src/ext/kv/map_kv.ts
@@ -77,7 +77,7 @@ export class MapKv implements DenoKv {
     if (this.clearOnClose) this.map.clear();
   }
 
-  delete(key: DenoKvStrictKey) {
+  delete(key: DenoKvStrictKey): void {
     this.map.delete(jsonStringify(key));
     this.watchers.forEach((w) => w.update(key));
   }

--- a/src/ext/kv/map_kv.ts
+++ b/src/ext/kv/map_kv.ts
@@ -78,7 +78,7 @@ export class MapKv implements DenoKv {
   async close(): Promise<void> {
     this.watchers.forEach((w) => w.cancel());
     this.listener?.resolve();
-    await this.atomicLock.cancel();
+    await this.atomicLock.close();
     if (this.clearOnClose) await this.map.clear();
   }
 

--- a/src/ext/kv/types.ts
+++ b/src/ext/kv/types.ts
@@ -9,7 +9,7 @@ export type BasicMap<K, V> = {
    * @param value - Value of the entry.
    * @returns void
    */
-  set(key: K, value: V): void;
+  set(key: K, value: V): Promise<void | Map<any, any>> | void | Map<any, any>;
 
   /**
    * Get a key/value entry from the map.
@@ -17,7 +17,7 @@ export type BasicMap<K, V> = {
    * @param key - Key that identifies the entry.
    * @returns The entry value or undefined if it does not exist in the map.
    */
-  get(key: K): V | undefined;
+  get(key: K): Promise<V | undefined> | V | undefined;
 
   /**
    * Delete a key/value entry from the map.
@@ -25,17 +25,17 @@ export type BasicMap<K, V> = {
    * @param key - Key that identifies the entry.
    * @returns void
    */
-  delete(key: K): void;
+  delete(key: K): Promise<void | boolean> | void | boolean;
 
   /**
    * Get an iterator of the key/value entries in the map.
    *
    * @returns An IterableIterator of [key, value] entries.
    */
-  entries(): IterableIterator<[K, V]>;
+  entries(): AsyncIterableIterator<[K, V]> | IterableIterator<[K, V]>;
 
   /** Removes all key/value entries from the map. */
-  clear(): void;
+  clear(): Promise<void> | void;
 };
 
 /** Options when constructing a new MapKv instance. */

--- a/src/ext/migrate/migrate.ts
+++ b/src/ext/migrate/migrate.ts
@@ -1,4 +1,5 @@
 import { KVDEX_KEY_PREFIX } from "../../constants.ts";
+import type { DenoKvStrictKey } from "../../types.ts";
 import type { MigrateOptions } from "./types.ts";
 
 /**
@@ -24,8 +25,8 @@ export async function migrate({
   target,
   all,
 }: MigrateOptions): Promise<void> {
-  const iter = source.list({ prefix: all ? [] : [KVDEX_KEY_PREFIX] });
+  const iter = await source.list({ prefix: all ? [] : [KVDEX_KEY_PREFIX] });
   for await (const { key, value } of iter) {
-    await target.set(key, value);
+    await target.set(key as DenoKvStrictKey, value);
   }
 }

--- a/src/ext/migrate/types.ts
+++ b/src/ext/migrate/types.ts
@@ -1,10 +1,12 @@
+import type { DenoKv } from "../../types.ts";
+
 /** Options for migrating entries from a source KV instance to a target KV instance */
 export type MigrateOptions = {
   /** Source KV. */
-  source: Deno.Kv;
+  source: DenoKv;
 
   /** Target KV. */
-  target: Deno.Kv;
+  target: DenoKv;
 
   /**
    * Flag indicating whether to migrate all entries or only kvdex specific entries.

--- a/src/kvdex.ts
+++ b/src/kvdex.ts
@@ -224,7 +224,7 @@ export class Kvdex<const TSchema extends Schema<SchemaDefinition>> {
    */
   async wipe(): Promise<void> {
     // Create iterator
-    const iter = this.kv.list({ prefix: [KVDEX_KEY_PREFIX] });
+    const iter = await this.kv.list({ prefix: [KVDEX_KEY_PREFIX] });
 
     // Collect all kvdex keys
     const keys: DenoKvStrictKey[] = [];

--- a/src/types.ts
+++ b/src/types.ts
@@ -1008,7 +1008,7 @@ export type DenoKv = {
   list(
     selector: DenoKvListSelector,
     options?: DenoKvListOptions,
-  ): DenoKvListIterator;
+  ): Promise<DenoKvListIterator> | DenoKvListIterator;
 
   listenQueue(handler: (value: unknown) => unknown): Promise<void>;
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -82,7 +82,7 @@ export async function useKv(
     : await Deno.openKv(":memory:");
 
   const result = await fn(kv);
-  kv.close();
+  await kv.close();
 
   if (typeof result === "function") {
     await result();


### PR DESCRIPTION
This PR expands the `BasicMap` interface to support async versions of all methods, as well as the `DenoKv` interface to support async `list` operations.

Related to #250 