### PR TITLE
Add session storage support to docs & make passing Storage implementation mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ _Supported Deno versions:_ **^2.3.0**
 - Listen to real-time data updates.
 - Support for pagination and filtering.
 - Message queues at database and collection level with topics.
-- Support for different KV-backends, such as `Map`, `Storage` and `IndexedDB`.
+- Support for alternative KV-backends, such as `Map`, `Storage` and `IndexedDB`.
 
 ## Table of Contents
 
@@ -1624,10 +1624,10 @@ await migrate({
 
 ### KV
 
-Support for alternative KV backends, such as `Map`, `localStorage` and
-`sessionStorage`. Can be used to employ `kvdex` in the browser or other
-environments where Deno's KV store is not available, or simply to integrate with
-other data backends.
+Extends support to alternative KV-backends, such as `Map`, `Storage` and
+`IndexedDB`. Can be used to employ `kvdex` in the browser or other environments
+where Deno's KV store is not available, or simply to integrate with other data
+backends.
 
 #### Map
 

--- a/README.md
+++ b/README.md
@@ -1626,7 +1626,7 @@ await migrate({
 
 Support for alternative KV backends, such as `Map`, `localStorage` and
 `sessionStorage`. Can be used to employ `kvdex` in the browser or other
-environments where Deno's KV store is not available, or to simply integrate with
+environments where Deno's KV store is not available, or simply to integrate with
 other data backends.
 
 #### Map

--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ _Supported Deno versions:_ **^2.3.0**
 - Listen to real-time data updates.
 - Support for pagination and filtering.
 - Message queues at database and collection level with topics.
-- Support for different KV-backends, such as `Map`, `localStorage` and
-  `IndexedDB`.
+- Support for different KV-backends, such as `Map`, `Storage` and `IndexedDB`.
 
 ## Table of Contents
 
@@ -1625,16 +1624,19 @@ await migrate({
 
 ### KV
 
-Support for alternative KV backends, such as `Map` and `localStorage`. Can be
-used to employ `kvdex` in the browser or other environments where Deno's KV
-store is not available, or to adapt other database backends.
+Support for alternative KV backends, such as `Map`, `localStorage` and
+`sessionStorage`. Can be used to employ `kvdex` in the browser or other
+environments where Deno's KV store is not available, or to simply integrate with
+other data backends.
 
 #### Map
 
 Support for `Map` as KV backend.
 
+- Provides an implementation of the Deno KV interface that integrates with
+  `Map`.
 - Provides a storage adapter, extending backend support to the `Storage`
-  interface (e.g. `localStorage`).
+  interface (e.g. `localStorage` and `sessionStorage`).
 - Provides an `IndexedDB` adapter, enabling the use of `IndexedDB` as a KV
   backend.
 
@@ -1657,6 +1659,17 @@ import { MapKv, StorageAdapter } from "@olli/kvdex/kv/map";
 
 // Equivalent to `new StorageAdapter(localStorage)`
 const map = new StorageAdapter();
+const kv = new MapKv({ map });
+const db = kvdex({ kv });
+```
+
+Create a session-scoped database using `sessionStorage` as the KV backend:
+
+```ts
+import { kvdex } from "@olli/kvdex";
+import { MapKv, StorageAdapter } from "@olli/kvdex/kv/map";
+
+const map = new StorageAdapter(sessionStorage);
 const kv = new MapKv({ map });
 const db = kvdex({ kv });
 ```

--- a/README.md
+++ b/README.md
@@ -1657,8 +1657,7 @@ Create a persistent database using `localStorage` as the KV backend:
 import { kvdex } from "@olli/kvdex";
 import { MapKv, StorageAdapter } from "@olli/kvdex/kv/map";
 
-// Equivalent to `new StorageAdapter(localStorage)`
-const map = new StorageAdapter();
+const map = new StorageAdapter(localStorage);
 const kv = new MapKv({ map });
 const db = kvdex({ kv });
 ```

--- a/src/ext/kv/map/map_kv.ts
+++ b/src/ext/kv/map/map_kv.ts
@@ -35,22 +35,33 @@ import {
  *
  * @example
  * ```ts
+ * import { MapKv } from "@olli/kvdex/kv";
  * // Initializes a new KV instance wrapping the built-in `Map`
  * const kv = new MapKv()
  * ```
  *
  * @example
  * ```ts
+ * import { MapKv, StorageAdapter } from "@olli/kvdex/kv";
  * // Initializes a new KV instance utilizing `localStorage` as it's backend
- * const map = new StorageAdapter()
+ * const map = new StorageAdapter(localStorage)
  * const kv = new MapKv({ map })
  * ```
  *
  * @example
  * ```ts
- * // Initializes a new ephimeral KV instance explicitly utilizing `localStorage` as it's backend
- * const map = new StorageAdapter(localStorage)
- * const kv = new MapKv({ map, clearOnClose: true })
+ * import { MapKv, StorageAdapter } from "@olli/kvdex/kv";
+ * // Initializes a new KV instance utilizing `sessionStorage` as it's backend
+ * const map = new StorageAdapter(sessionStorage)
+ * const kv = new MapKv({ map })
+ * ```
+ *
+ * @example
+ * ```ts
+ * import { MapKv, indexedDbAdapter } from "@olli/kvdex/kv";
+ * // Initializes a new KV instance utilizing `IndexedDB` as it's backend
+ * const map = await indexedDbAdapter()
+ * const kv = new MapKv({ map })
  * ```
  */
 export class MapKv implements DenoKv {

--- a/src/ext/kv/map/mod.ts
+++ b/src/ext/kv/map/mod.ts
@@ -21,7 +21,18 @@
  * import { MapKv, StorageAdapter } from "@olli/kvdex/kv/map";
  *
  * // Create a persistent database using `localStorage` as the KV backend
- * const map = new StorageAdapter(); // Equivalent to `new StorageAdapter(localStorage)`
+ * const map = new StorageAdapter(localStorage);
+ * const kv = new MapKv({ map });
+ * const db = kvdex({ kv });
+ * ```
+ *
+ * @example
+ * ```ts
+ * import { kvdex } from "@olli/kvdex";
+ * import { MapKv, StorageAdapter } from "@olli/kvdex/kv/map";
+ *
+ * // Create a session-scoped database using `sessionStorage` as the KV backend
+ * const map = new StorageAdapter(sessionStorage);
  * const kv = new MapKv({ map });
  * const db = kvdex({ kv });
  * ```

--- a/src/ext/kv/map/storage_adapter.ts
+++ b/src/ext/kv/map/storage_adapter.ts
@@ -2,28 +2,26 @@ import { jsonParse, jsonStringify } from "../../../common/json.ts";
 import type { BasicMap } from "./types.ts";
 
 /**
- * BasicMap adapter for `Storage`.
+ * BasicMap adapter for the `Storage` interface.
  *
- * Enables a `Storage` object, such as `localStorage`, to be utilized as a basic map.
- *
- * Wraps `localStorage` by default.
+ * Enables a `Storage` object, such as `localStorage` and `sessionStorage`, to be utilized as a BasicMap.
  *
  * @example
  * ```ts
  * // Creates a new BasicMap, wrapping `localStorage`
- * const map = new StorageAdapter()
+ * const map = new StorageAdapter(localStorage)
  * ```
  *
  * @example
  * ```ts
- * // Creates a new BasicMap, explicitly wrapping `localStorage`
- * const map = new StorageAdapter(localStorage)
+ * // Creates a new BasicMap, wrapping `sessionStorage`
+ * const map = new StorageAdapter(sessionStorage)
  * ```
  */
 export class StorageAdapter<K, V> implements BasicMap<K, V> {
   private storage: Storage;
 
-  constructor(storage: Storage = localStorage) {
+  constructor(storage: Storage) {
     this.storage = storage;
   }
 

--- a/src/ext/kv/map/storage_adapter.ts
+++ b/src/ext/kv/map/storage_adapter.ts
@@ -4,7 +4,7 @@ import type { BasicMap } from "./types.ts";
 /**
  * BasicMap adapter for the `Storage` interface.
  *
- * Enables a `Storage` object, such as `localStorage` and `sessionStorage`, to be utilized as a BasicMap.
+ * Enables a `Storage` object, such as `localStorage` or `sessionStorage`, to be utilized as a BasicMap.
  *
  * @example
  * ```ts

--- a/src/ext/kv/mod.ts
+++ b/src/ext/kv/mod.ts
@@ -9,7 +9,7 @@
  * ## Map
  *
  * Support for `Map` as KV backend.
- * - Provides an implementation of the Deno KV interface that integrates with`Map`.
+ * - Provides an implementation of the Deno KV interface that integrates with `Map`.
  * - Provides a storage adapter, extending backend support to the `Storage` interface (e.g. `localStorage` and `sessionStorage`).
  * - Provides an `IndexedDB` adapter, enabling the use of `IndexedDB` as a KV backend.
  *

--- a/src/ext/kv/mod.ts
+++ b/src/ext/kv/mod.ts
@@ -4,7 +4,7 @@
  * Support for alternative KV backends, such as `Map`, `Storage`, and `IndexedDB`.
  *
  * Can be used to employ `kvdex` in the browser or other environments where Deno's KV store is not available,
- * or to simply integrate with other database backends.
+ * or simply to integrate with other database backends.
  *
  * ## Map
  *

--- a/src/ext/kv/mod.ts
+++ b/src/ext/kv/mod.ts
@@ -1,15 +1,16 @@
 /**
  * @module # KV
  *
- * Support for alternative KV backends, such as `Map`, `localStorage`, and `IndexedDB`.
+ * Support for alternative KV backends, such as `Map`, `Storage`, and `IndexedDB`.
  *
  * Can be used to employ `kvdex` in the browser or other environments where Deno's KV store is not available,
- * or to adapt other database backends.
+ * or to simply integrate with other database backends.
  *
  * ## Map
  *
  * Support for `Map` as KV backend.
- * - Provides a storage adapter, extending backend support to the `Storage` interface (e.g. `localStorage`).
+ * - Provides an implementation of the Deno KV interface that integrates with`Map`.
+ * - Provides a storage adapter, extending backend support to the `Storage` interface (e.g. `localStorage` and `sessionStorage`).
  * - Provides an `IndexedDB` adapter, enabling the use of `IndexedDB` as a KV backend.
  *
  * @example
@@ -28,7 +29,18 @@
  * import { MapKv, StorageAdapter } from "@olli/kvdex/kv";
  *
  * // Create a persistent database using `localStorage` as the KV backend
- * const map = new StorageAdapter(); // Equivalent to `new StorageAdapter(localStorage)`
+ * const map = new StorageAdapter(localStorage);
+ * const kv = new MapKv({ map });
+ * const db = kvdex({ kv });
+ * ```
+ *
+ * @example
+ * ```ts
+ * import { kvdex } from "@olli/kvdex";
+ * import { MapKv, StorageAdapter } from "@olli/kvdex/kv";
+ *
+ * // Create a session-scoped database using `sessionStorage` as the KV backend:
+ * const map = new StorageAdapter(sessionStorage);
  * const kv = new MapKv({ map });
  * const db = kvdex({ kv });
  * ```

--- a/tests/db/properties.test.ts
+++ b/tests/db/properties.test.ts
@@ -22,20 +22,24 @@ Deno.test({
     });
 
     await t.step("Should allow in-memory Map KV type", async () => {
-      const kv = new MapKv({ map: new Map() });
+      const kv = new MapKv({ map: new Map(), clearOnClose: true });
       kvdex({ kv });
       await kv.close();
     });
 
     await t.step("Should allow local storage Map KV type", async () => {
-      const kv = new MapKv({ map: new StorageAdapter(localStorage) });
+      const kv = new MapKv({
+        map: new StorageAdapter(localStorage),
+        clearOnClose: true,
+      });
+
       kvdex({ kv });
       await kv.close();
     });
 
     await t.step("Should allow IndexedDB Map KV type", async () => {
       const map = await indexedDbAdapter();
-      const kv = new MapKv({ map });
+      const kv = new MapKv({ map, clearOnClose: true });
       kvdex({ kv });
       await kv.close();
     });

--- a/tests/ext/kv.test.ts
+++ b/tests/ext/kv.test.ts
@@ -4,6 +4,7 @@ import {
   useIndexedDbMap,
   useLocalStorageMap,
   useMapKv,
+  useSessionStorageMap,
 } from "../utils.ts";
 import { MapKv } from "../../src/ext/kv/map/mod.ts";
 import type { BasicMap } from "../../src/ext/kv/map/types.ts";
@@ -207,6 +208,77 @@ Deno.test({
 
       await t.step("Should delete all entries", async () => {
         await useLocalStorageMap((map) => {
+          const entries = [
+            ["1", 10],
+            ["2", 20],
+            ["3", 30],
+            ["4", 40],
+            ["5", 50],
+          ] as const;
+
+          for (const [key, val] of entries) {
+            map.set(key, val);
+          }
+
+          const storeEntries1 = Array.from(map.entries());
+          assertEquals(storeEntries1.length, entries.length);
+
+          map.clear();
+          const storeEntries2 = Array.from(map.entries());
+          assertEquals(storeEntries2.length, 0);
+        });
+      });
+    });
+
+    await t.step("storage_adapter (sessionStorage)", async (t) => {
+      await t.step("Should set and get new entry", async () => {
+        await useSessionStorageMap((map) => {
+          const key = "key";
+          const val = 10;
+          map.set(key, val);
+          const item = map.get(key);
+          assertEquals(val, item);
+        });
+      });
+
+      await t.step("Should get all entries", async () => {
+        await useSessionStorageMap((map) => {
+          const entries = [
+            ["1", 10],
+            ["2", 20],
+            ["3", 30],
+            ["4", 40],
+            ["5", 50],
+          ] as const;
+
+          for (const [key, val] of entries) {
+            map.set(key, val);
+          }
+
+          const storeEntries = Array.from(map.entries());
+          assertEquals(entries.length, storeEntries.length);
+
+          for (const [key, val] of storeEntries) {
+            assert(entries.some(([k, v]) => k === key && v === val));
+          }
+        });
+      });
+
+      await t.step("Should delete entry by key", async () => {
+        await useSessionStorageMap((map) => {
+          const key = "key";
+          const val = 10;
+          map.set(key, val);
+          const item1 = map.get(key);
+          assertEquals(item1, val);
+          map.delete(key);
+          const item2 = map.get(key);
+          assertEquals(item2, undefined);
+        });
+      });
+
+      await t.step("Should delete all entries", async () => {
+        await useSessionStorageMap((map) => {
           const entries = [
             ["1", 10],
             ["2", 20],

--- a/tests/ext/kv.test.ts
+++ b/tests/ext/kv.test.ts
@@ -1,5 +1,10 @@
 import { assert, assertEquals } from "@std/assert";
-import { sleep, useIndexedDbMap, useMapKv, useStorageMap } from "../utils.ts";
+import {
+  sleep,
+  useIndexedDbMap,
+  useLocalStorageMap,
+  useMapKv,
+} from "../utils.ts";
 import { MapKv } from "../../src/ext/kv/map/mod.ts";
 import type { BasicMap } from "../../src/ext/kv/map/types.ts";
 
@@ -155,7 +160,7 @@ Deno.test({
 
     await t.step("storage_adapter (localStorage)", async (t) => {
       await t.step("Should set and get new entry", async () => {
-        await useStorageMap((map) => {
+        await useLocalStorageMap((map) => {
           const key = "key";
           const val = 10;
           map.set(key, val);
@@ -165,7 +170,7 @@ Deno.test({
       });
 
       await t.step("Should get all entries", async () => {
-        await useStorageMap((map) => {
+        await useLocalStorageMap((map) => {
           const entries = [
             ["1", 10],
             ["2", 20],
@@ -188,7 +193,7 @@ Deno.test({
       });
 
       await t.step("Should delete entry by key", async () => {
-        await useStorageMap((map) => {
+        await useLocalStorageMap((map) => {
           const key = "key";
           const val = 10;
           map.set(key, val);
@@ -201,7 +206,7 @@ Deno.test({
       });
 
       await t.step("Should delete all entries", async () => {
-        await useStorageMap((map) => {
+        await useLocalStorageMap((map) => {
           const entries = [
             ["1", 10],
             ["2", 20],

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -117,8 +117,10 @@ export async function useKv(
 
   const kv = kvArg === "map"
     ? new MapKv({ clearOnClose: true })
-    : kvArg === "map_local"
+    : kvArg === "map_local_storage"
     ? new MapKv({ map: new StorageAdapter(localStorage), clearOnClose: true })
+    : kvArg === "map_session_storage"
+    ? new MapKv({ map: new StorageAdapter(sessionStorage), clearOnClose: true })
     : kvArg === "map_indexed_db"
     ? new MapKv({
       map: await indexedDbAdapter(),
@@ -151,10 +153,18 @@ export async function useMapKv(
   await mapKv.close();
 }
 
-export async function useStorageMap(
+export async function useLocalStorageMap(
   fn: (store: StorageAdapter<any, any>) => unknown,
 ) {
   const store = new StorageAdapter(localStorage);
+  await fn(store);
+  store.clear();
+}
+
+export async function useSessionStorageMap(
+  fn: (store: StorageAdapter<any, any>) => unknown,
+) {
+  const store = new StorageAdapter(sessionStorage);
   await fn(store);
   store.clear();
 }


### PR DESCRIPTION
This PR changes the public API of the StorageAdapter by making it mandatory to pass the implementation of Storage. This is deliberate and part of the 4.0 update. This PR also adds sessionStorage examples to the README and JSDoc + adds test cases for sessionStorage StorageAdapter.